### PR TITLE
upgrade prometheus metrics formatter to fix issue

### DIFF
--- a/src/airbag.csproj
+++ b/src/airbag.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
   </ItemGroup>
 

--- a/src/airbag.csproj
+++ b/src/airbag.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.AspNetCore" Version="2.0.0-preview1" />
-    <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="2.0.0-preview1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="App.Metrics.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Prometheus is now more strict about the metric capitalization. [Issue](https://github.com/AppMetrics/Prometheus/issues/40)
We should use the new version otherwise Prometheus won't be able to scrape it soon.