### PR TITLE
move airbag metrics to new path, always allow /metrics for prometheus…

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,7 +20,6 @@ namespace Airbag
 
         private static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseMetrics()
                 .UseConfiguration(_configuration)
                 .ConfigureMetricsWithDefaults(
                     builder =>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,13 +20,18 @@ namespace Airbag
 
         private static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseMetrics()
                 .UseConfiguration(_configuration)
                 .ConfigureMetricsWithDefaults(
                     builder =>
                     {
                         builder.Configuration.Configure(
-                            options => { options.Enabled = _configuration.GetValue<bool>("COLLECT_METRICS"); });
+                            options =>
+                            {
+                                options.Enabled = _configuration.GetValue<bool>("COLLECT_METRICS");
+                            });
                     })
+                .ConfigureAppMetricsHostingConfiguration(options => { options.MetricsEndpoint = "/airbag/metrics"; })
                 .ConfigureLogging(builder =>
                 {
                     builder.ClearProviders();

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -100,11 +100,12 @@ namespace Airbag
             app.UseAuthentication();
 
             var unauthenticatedConfig = _configuration.GetValue<string>("UNAUTHENTICATED_ROUTES");
-            IEnumerable<string> unauthenticatedRoutes = new List<string>();
+            
+            IEnumerable<string> unauthenticatedRoutes = new List<string>() { "/metrics" };
 
             if (unauthenticatedConfig != null)
             {
-                unauthenticatedRoutes = unauthenticatedConfig.Split(',');
+                unauthenticatedRoutes = unauthenticatedRoutes.Concat(unauthenticatedConfig.Split(','));
             }
 
             app.UseAuthenticatedRoutes(unauthenticatedRoutes, GetProviders().Select(provider => provider.Name));


### PR DESCRIPTION
Currently, airbag exposes his own metrics in `/metrics`, meaning, kubernetes is not able to scrape metrics from the proxied service without directly exposing his port which is a security issue.

This PR moves the airbag metrics to `/airbag/metrics` and always forward requests to `/metrics` in unauthenticated fashion to the proxied service.