### PR TITLE
added support for authorization based on OPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: csharp
 mono: none
 dotnet: 2.2
 
-install: 
-  - dotnet restore
-
 before_script:
   - dotnet test UnitTests/
   - cd BlackboxTests && docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: csharp
 mono: none
-dotnet: 2.1
+dotnet: 2.2
 
 install: 
-  - cd src && dotnet restore
+  - dotnet restore
 
 before_script:
-  - cd ../BlackboxTests && docker-compose up -d
+  - dotnet test UnitTests/
+  - cd BlackboxTests && docker-compose up -d
 
 script:
   - dotnet test

--- a/BlackboxTests/docker-compose.yml
+++ b/BlackboxTests/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     - valid_auth_server
     - auth_server_with_different_issuer
     - protected_api
+    - opa
     environment:
     - ASPNETCORE_ENVIRONMENT=Development
     - AUTHORITY=http://valid_auth_server
@@ -19,6 +20,9 @@ services:
     - BACKEND_SERVICE_PORT=8080
     - COLLECT_METRICS=false
     - UNAUTHENTICATED_ROUTES=/isAlive,/foo*
+    - OPA_QUERY_PATH=protected_api/allow
+    - OPA_MODE=Enabled
+    - OPA_URL=http://opa:8181
     ports:
     - "5001:80"
 
@@ -56,3 +60,11 @@ services:
 
   protected_api:
     image: jmalloc/echo-server
+
+  opa:
+    image: openpolicyagent/opa
+    command: run --server /policies
+    ports: 
+     - 8181:8181
+    volumes: 
+     - $PWD/../open-policy-agent:/policies

--- a/BlackboxTests/docker-compose.yml
+++ b/BlackboxTests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - OPA_MODE=Enabled
     - OPA_URL=http://opa:8181
     ports:
-    - "5001:80"
+    - "5001:5001"
 
   valid_auth_server:
     build: ../SampleAuthServer

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ example: `/isAlive,/health,/something/anonymous`
 If a route contains a wildcard ( * ) then all matching routes will not be authenticated (For example - `/swagger/*` will cause all routes which start with `/swagger/` to be unauthenticated.   
 * **COLLECT_METRICS** - Enable or disable metrics collection. Metrics are collected using [AppMetrics](https://github.com/AppMetrics/AppMetrics).
 Metrics will be available under `/airbag/metrics`
+* **AUTHORIZED_ROUTES_ENABLED** - Enable or disable route white-listing.
 
 ### Using with multiple auth providers
 To use multiple auth providers, provide these parmaters for every provider as a prefix:
@@ -39,3 +40,17 @@ To use multiple auth providers, provide these parmaters for every provider as a 
 - ISSUER_BAR=http://bar
 - AUDIENCE_BAR=bar_api
 ```
+
+### External Authorization with Open Policy Agent
+Airbag support authorization of incoming request with [Open Policy Agent](https://www.openpolicyagent.org)(OPA). 
+If enabled, Airbag will query OPA for a decision on each incoming request, and based on OPA decision approve or deny the request.
+Approved requests will be passed to upstream, denied request will return to client with 403 status code.
+
+#### Configuration
+To use OPA, you need to configure the following environment variables:
+* OPA_URL - The URL of the OPA server
+* OPA_QUERY_PATH - the path used for OPA query. This path should return a single bollean result.
+* OPA_MODE - The mode of OPA authorization. Support 3 values:
+  * Disabled - Do not query OPA at all. This is the default value.
+  * LogOnly - Query OPA, but only log result - do not perform authorization. 
+  * Enabled - Query OPA and perform authorization.

--- a/UnitTests/OpenPolicyAgent/OpenPolicyAgentMiddlewareTests.cs
+++ b/UnitTests/OpenPolicyAgent/OpenPolicyAgentMiddlewareTests.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Linq;
+using Airbag.OpenPolicyAgent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Airbag.UnitTests.OpenPolicyAgent
+{
+    public class OpenPolicyAgentMiddlewareTests
+    {
+        private Mock<IOpenPolicyAgent> mOpenPolicyAgent;
+        private OpenPolicyAgentAuthorizationMiddlewareConfiguration mConfiguration;
+        private OpenPolicyAgentAuthorizationMiddleware mTarget;
+        private DefaultHttpContext mHttpContext;
+
+        public OpenPolicyAgentMiddlewareTests()
+        {
+            mOpenPolicyAgent = new Mock<IOpenPolicyAgent>();
+            mConfiguration = new OpenPolicyAgentAuthorizationMiddlewareConfiguration { QueryPath = "dummy"};
+            var logger = new LoggerFactory().CreateLogger<OpenPolicyAgentAuthorizationMiddleware>();
+
+            mTarget = new OpenPolicyAgentAuthorizationMiddleware(
+                new Mock<RequestDelegate>().Object,
+                mOpenPolicyAgent.Object,
+                logger,
+                mConfiguration);
+
+            mHttpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public async Task InvokeAsync_OpaDisabled_NotCallingOPA()
+        {
+            mConfiguration.Mode = OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Disabled;
+
+            await mTarget.InvokeAsync(mHttpContext);
+
+            mOpenPolicyAgent.Verify(
+                x => x.Query(It.IsAny<string>(), It.IsAny<OpenPolicyAgentQueryRequest>()),
+                Times.Never);
+
+            Assert.Equal(200, mHttpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_CallingOPA_WithAllRelevantRequestParams()
+        {
+            mConfiguration.Mode = OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Enabled;
+
+            var queryList = new Dictionary<string, StringValues>
+            {
+                { "a", new StringValues(new[] { "b", "c" }) }
+            };
+            var captures = new List<OpenPolicyAgentQueryRequest>();
+
+            mHttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("a", "b"), new Claim("a", "c") }));
+
+            mHttpContext.Request.Path = "/api/v1/someController";
+            mHttpContext.Request.Method = "GET";
+            mHttpContext.Request.Query = new QueryCollection(queryList);
+
+            mOpenPolicyAgent.Setup(x => x.Query(mConfiguration.QueryPath, Capture.In(captures)))
+                .Returns(Task.FromResult(new OpenPolicyAgentQueryResponse { Result = true}));
+
+            await mTarget.InvokeAsync(mHttpContext);
+
+            mOpenPolicyAgent.Verify(
+                x => x.Query(mConfiguration.QueryPath, It.IsAny<OpenPolicyAgentQueryRequest>()),
+                Times.Once);
+
+           var opaRequest = captures.Single();
+
+            Assert.Equal("GET", opaRequest.Input.Method);
+            Assert.Equal(new[] { "api", "v1", "someController"}, opaRequest.Input.Path);
+
+            var queryItem = opaRequest.Input.Query.Single();
+
+            Assert.Equal("a", queryItem.Key);
+            Assert.Equal(new[] { "b", "c" }, queryItem.Value);
+
+            var claimItem = opaRequest.Input.Claims.Single();
+
+            Assert.Equal("a", claimItem.Key);
+            Assert.Equal(new[] { "b", "c" }, claimItem.Value);
+        }
+
+        [Theory]
+        [InlineData(
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Enabled, 
+            true,
+            200)]
+        [InlineData(
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Enabled,
+            false,
+            403)]
+        [InlineData(
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.LogOnly,
+            true,
+            200)]
+        [InlineData(
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.LogOnly,
+            false,
+            200)]
+        public async Task InvokeAsync_OpaReturnsFalse_RequestDenied(
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode mode,
+            bool opaReturnValue,
+            int expectedStatusCode)
+        {
+            mConfiguration.Mode = mode;
+            mOpenPolicyAgent.Setup(x => x.Query(mConfiguration.QueryPath, It.IsAny<OpenPolicyAgentQueryRequest>()))
+                .Returns(Task.FromResult(new OpenPolicyAgentQueryResponse { Result = opaReturnValue }));
+
+            await mTarget.InvokeAsync(mHttpContext);
+
+            Assert.Equal(expectedStatusCode, mHttpContext.Response.StatusCode);
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Airbag.csproj" />
+    <ProjectReference Include="..\src\airbag.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Airbag.UnitTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="moq" Version="4.10.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="restease" Version="1.4.9" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Airbag.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="OpenPolicyAgent\" />
+  </ItemGroup>
+</Project>

--- a/airbag.sln
+++ b/airbag.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
@@ -7,6 +7,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlackboxTests", "BlackboxTests\BlackboxTests.csproj", "{AFE1AAFF-2161-41AE-BBDE-E9D9257A9E73}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAuthServer", "SampleAuthServer\SampleAuthServer.csproj", "{3203E8EF-8F6E-4C4E-8200-388F046AE697}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +56,18 @@ Global
 		{3203E8EF-8F6E-4C4E-8200-388F046AE697}.Release|x64.Build.0 = Release|Any CPU
 		{3203E8EF-8F6E-4C4E-8200-388F046AE697}.Release|x86.ActiveCfg = Release|Any CPU
 		{3203E8EF-8F6E-4C4E-8200-388F046AE697}.Release|x86.Build.0 = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Debug|x86.Build.0 = Debug|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|x64.Build.0 = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3658207-2AB9-4F7C-8FA2-CA68CE6DB38E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/airbag.sln
+++ b/airbag.sln
@@ -2,7 +2,7 @@
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Airbag", "src\Airbag.csproj", "{00F88900-7D19-4768-A48B-198BE0B0ECA8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Airbag", "src\airbag.csproj", "{00F88900-7D19-4768-A48B-198BE0B0ECA8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlackboxTests", "BlackboxTests\BlackboxTests.csproj", "{AFE1AAFF-2161-41AE-BBDE-E9D9257A9E73}"
 EndProject

--- a/open-policy-agent/policy.rego
+++ b/open-policy-agent/policy.rego
@@ -1,0 +1,3 @@
+package protected_api.allow
+
+default allow=true

--- a/open-policy-agent/policy.rego
+++ b/open-policy-agent/policy.rego
@@ -1,3 +1,3 @@
-package protected_api.allow
+package protected_api
 
 default allow=true

--- a/src/AuthMiddleware.cs
+++ b/src/AuthMiddleware.cs
@@ -31,6 +31,8 @@ namespace Airbag
             }));
 
             var user = results.FirstOrDefault(res => res != null && res.Succeeded)?.Principal;
+
+            ctx.Request.HttpContext.User = user;
             
             return user != null;
         }

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -15,4 +15,5 @@ RUN addgroup dotnet && adduser -D -G dotnet -h /home/dotnet dotnet
 USER dotnet
 WORKDIR /home/dotnet/app
 COPY --from=build-env /app/out .
+ENV ASPNETCORE_URLS=http://+:5001
 ENTRYPOINT ["dotnet", "airbag.dll"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore-build:2.0 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,9 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0
-WORKDIR /app
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.5-alpine
+RUN addgroup dotnet && adduser -D -G dotnet -h /home/dotnet dotnet
+USER dotnet
+WORKDIR /home/dotnet/app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "airbag.dll"]

--- a/src/OpenPolicyAgent/IOpenPolicyAgent.cs
+++ b/src/OpenPolicyAgent/IOpenPolicyAgent.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Airbag.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RestEase;
+
+namespace Airbag.OpenPolicyAgent
+{
+    public class OpenPolicyAgentInput
+    {
+        [JsonProperty("path")]
+        public string[] Path { get; set; }
+
+        [JsonProperty("method")]
+        public string Method { get; set; }
+
+        [JsonConverter(typeof(KeyValuePairConverter))]
+        [JsonProperty("query")]
+        public IEnumerable<KeyValuePair<string, string[]>> Query { get; set; }
+
+        [JsonConverter(typeof(KeyValuePairConverter))]
+        [JsonProperty("claims")]
+        public IEnumerable<KeyValuePair<string,string[]>> Claims { get; set; }
+    }
+
+    public class OpenPolicyAgentQueryRequest
+    {
+        [JsonProperty("input")]
+        public OpenPolicyAgentInput Input { get; set; }
+    }
+
+    public class OpenPolicyAgentQueryResponse
+    {
+        [JsonProperty("result")]
+        public bool? Result { get; set; }
+
+        [JsonProperty("decision_id")]
+        public string DecisionId { get; set; }
+    }
+
+    public interface IOpenPolicyAgent
+    {
+        [Post("v1/data/{query}")]
+        Task<OpenPolicyAgentQueryResponse> Query([Path(UrlEncode = false)] string query, [Body]OpenPolicyAgentQueryRequest request);
+    }
+}

--- a/src/OpenPolicyAgent/OpenPolicyAgentAuthorizationMiddleware.cs
+++ b/src/OpenPolicyAgent/OpenPolicyAgentAuthorizationMiddleware.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using RestEase;
+
+namespace Airbag.OpenPolicyAgent
+{
+    public class OpenPolicyAgentAuthorizationMiddleware 
+    {
+        private readonly RequestDelegate _next;
+        private readonly IOpenPolicyAgent mOpenPolicyAgent;
+        private readonly ILogger<OpenPolicyAgentAuthorizationMiddleware> mLogger;
+        private readonly OpenPolicyAgentAuthorizationMiddlewareConfiguration mConfiguration;
+
+        public OpenPolicyAgentAuthorizationMiddleware(
+            RequestDelegate next, 
+            IOpenPolicyAgent openPolicyAgent,
+            ILogger<OpenPolicyAgentAuthorizationMiddleware> logger,
+            OpenPolicyAgentAuthorizationMiddlewareConfiguration configuration)
+        {
+            _next = next;
+            mOpenPolicyAgent = openPolicyAgent;
+            mLogger = logger;
+            mConfiguration = configuration;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if(mConfiguration.Mode 
+                == OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Disabled)
+            {
+                await _next(context);
+                return;
+            }
+
+            var path = context.Request.Path.Value.Split("/").Where(s => !string.IsNullOrEmpty(s)).ToArray();
+            var method = context.Request.Method;
+
+            var claims = context.Request.HttpContext.User.Claims
+                .GroupBy(c => c.Type)
+                .Select(g => KeyValuePair.Create(g.Key, g.Select(c => c.Value).ToArray()));
+
+            var request = new OpenPolicyAgentQueryRequest
+            {
+                Input = new OpenPolicyAgentInput
+                {
+                    Path = path,
+                    Method = method,
+                    Query = context.Request.Query.Select(x => KeyValuePair.Create(x.Key, x.Value.ToArray())),
+                    Claims = claims
+                }
+            };
+
+            mLogger.LogDebug("Running OPA query");
+
+            OpenPolicyAgentQueryResponse response = null;
+
+            try
+            {
+                response = await mOpenPolicyAgent.Query(mConfiguration.QueryPath, request);
+            }catch(ApiException e)
+            {
+                var decisionId = Guid.NewGuid().ToString();
+                mLogger.LogError("OPA request failed {excpetion}, decision id: {decisionId}", e, decisionId);
+                response = new OpenPolicyAgentQueryResponse
+                {
+                    Result = null,
+                    DecisionId = decisionId
+                };
+            }
+            
+            mLogger.LogInformation("OPA returned {result}, decision id: {decisionId}",
+                response.Result,
+                response.DecisionId);
+                
+            if ((response.Result == null || response.Result == false) && 
+                (mConfiguration.Mode == 
+                    OpenPolicyAgentAuthorizationMiddlewareConfiguration.AuthorizationMode.Enabled))
+            {
+                context.Response.StatusCode = 403;
+                await context.Response.WriteAsync("Unauthorized");
+                return;
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/OpenPolicyAgent/OpenPolicyAgentAuthorizationMiddlewareConfiguration.cs
+++ b/src/OpenPolicyAgent/OpenPolicyAgentAuthorizationMiddlewareConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+namespace Airbag.OpenPolicyAgent
+{
+    public class OpenPolicyAgentAuthorizationMiddlewareConfiguration
+    {
+        public enum AuthorizationMode
+        {
+            Disabled,
+            LogOnly,
+            Enabled
+        }
+
+        public AuthorizationMode Mode { get; set; }
+
+        public string QueryPath { get; set; }
+    }
+}

--- a/src/Utils/KeyValuePairConverter.cs
+++ b/src/Utils/KeyValuePairConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Airbag.Utils
+{
+    public class KeyValuePairConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IEnumerable<KeyValuePair<string, string[]>>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var pairs = value as IEnumerable<KeyValuePair<string, string[]>>;
+
+            if (pairs == null)
+            {
+                throw new InvalidOperationException("type not supported");
+            }
+
+            var jObject = new JObject(pairs.Select(pair => new JProperty(pair.Key, pair.Value)));
+
+            serializer.Serialize(writer, jObject);
+        }
+    }
+}

--- a/src/airbag.csproj
+++ b/src/airbag.csproj
@@ -5,12 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-    <Folder Include="OpenPolicyAgent\" />
-    <Folder Include="Utils\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/src/airbag.csproj
+++ b/src/airbag.csproj
@@ -1,18 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
+    <Folder Include="OpenPolicyAgent\" />
+    <Folder Include="Utils\" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Proxy" Version="0.2.0" />
+    <PackageReference Include="restease" Version="1.4.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Users can now add a [Open Policy Agent](https://github.com/open-policy-agent/opa) containers, and use it for authorization. Airbag will query OPA (if enabled) and based on the response decide if the request is authorized or not.
See the documentation I added to the readme for more information