### PR TITLE
added support for aws cognito idp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dotnet: 2.2
 
 before_script:
   - dotnet test UnitTests/
-  - cd BlackboxTests && docker-compose up -d
+  - cd BlackboxTests && docker-compose build && docker-compose up -d
 
 script:
   - dotnet test

--- a/BlackboxTests/OIDC_Auth_Tests.cs
+++ b/BlackboxTests/OIDC_Auth_Tests.cs
@@ -51,6 +51,15 @@ namespace BlackboxTests
         }
 
         [Fact]
+        public async Task RequestWithInvalidAudience_AnotherProvider_Return403Forbidden()
+        {
+            var tokenResponse = await _anotherValidTokenClient.RequestClientCredentialsAsync("api2");
+
+            var result = await SendRequest(tokenResponse.AccessToken);
+            Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
+        }
+
+        [Fact]
         public async Task RequestWithInvalidAudience_AirbagIgnoreAudience_ForwardRequestToBackendContainer()
         {
             var tokenResponse = await _validTokenClient.RequestClientCredentialsAsync("api2");
@@ -58,7 +67,7 @@ namespace BlackboxTests
             var result = await SendRequest(tokenResponse.AccessToken, "http://localhost:5006/");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
-        
+
         [Fact]
         public async Task RequestWithValidTokenFromAnotherProvider_ForwardRequestToBackendContainer()
         {

--- a/BlackboxTests/OIDC_Auth_Tests.cs
+++ b/BlackboxTests/OIDC_Auth_Tests.cs
@@ -49,6 +49,15 @@ namespace BlackboxTests
             var result = await SendRequest(tokenResponse.AccessToken);
             Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
         }
+
+        [Fact]
+        public async Task RequestWithInvalidAudience_AirbagIgnoreAudience_ForwardRequestToBackendContainer()
+        {
+            var tokenResponse = await _validTokenClient.RequestClientCredentialsAsync("api2", "http://localhost:5006/");
+       
+            var result = await SendRequest(tokenResponse.AccessToken);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
         
         [Fact]
         public async Task RequestWithValidTokenFromAnotherProvider_ForwardRequestToBackendContainer()
@@ -141,9 +150,9 @@ namespace BlackboxTests
             Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
         }
 
-        private static async Task<HttpResponseMessage> SendRequest(string jwtToken)
+        private static async Task<HttpResponseMessage> SendRequest(string jwtToken, string url = AirbagUrl)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, AirbagUrl);
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.SetBearerToken(jwtToken);
             var result = await new HttpClient().SendAsync(request);
             return result;

--- a/BlackboxTests/OIDC_Auth_Tests.cs
+++ b/BlackboxTests/OIDC_Auth_Tests.cs
@@ -53,9 +53,9 @@ namespace BlackboxTests
         [Fact]
         public async Task RequestWithInvalidAudience_AirbagIgnoreAudience_ForwardRequestToBackendContainer()
         {
-            var tokenResponse = await _validTokenClient.RequestClientCredentialsAsync("api2", "http://localhost:5006/");
+            var tokenResponse = await _validTokenClient.RequestClientCredentialsAsync("api2");
        
-            var result = await SendRequest(tokenResponse.AccessToken);
+            var result = await SendRequest(tokenResponse.AccessToken, "http://localhost:5006/");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
         

--- a/BlackboxTests/OIDC_Auth_Tests.cs
+++ b/BlackboxTests/OIDC_Auth_Tests.cs
@@ -40,6 +40,15 @@ namespace BlackboxTests
             var result = await SendRequest(tokenResponse.AccessToken);
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
+
+        [Fact]
+        public async Task RequestWithInvalidAudience_Return403Forbidden()
+        {
+            var tokenResponse = await _validTokenClient.RequestClientCredentialsAsync("api2");
+       
+            var result = await SendRequest(tokenResponse.AccessToken);
+            Assert.Equal(HttpStatusCode.Forbidden, result.StatusCode);
+        }
         
         [Fact]
         public async Task RequestWithValidTokenFromAnotherProvider_ForwardRequestToBackendContainer()

--- a/BlackboxTests/docker-compose.yml
+++ b/BlackboxTests/docker-compose.yml
@@ -35,12 +35,9 @@ services:
     - opa
     environment:
     - ASPNETCORE_ENVIRONMENT=Development
-    - AUTHORITY=http://valid_auth_server
-    - ISSUER=http://localhost:5002
-    - AUDIENCE=api1
-    - AUTHORITY_ANOTHER=http://another_valid_auth_server
-    - ISSUER_ANOTHER=http://localhost:5003
-    - VALIDATE_AUDIENCE__ANOTHER=false
+    - AUTHORITY_ANOTHER=http://valid_auth_server
+    - ISSUER_ANOTHER=http://localhost:5002
+    - VALIDATE_AUDIENCE_ANOTHER=false
     - BACKEND_HOST_NAME=protected_api
     - BACKEND_SERVICE_PORT=8080
     - COLLECT_METRICS=false

--- a/BlackboxTests/docker-compose.yml
+++ b/BlackboxTests/docker-compose.yml
@@ -26,6 +26,31 @@ services:
     ports:
     - "5001:5001"
 
+  airbag-without-aud-validation:
+    build: ../src
+    depends_on:
+    - valid_auth_server
+    - auth_server_with_different_issuer
+    - protected_api
+    - opa
+    environment:
+    - ASPNETCORE_ENVIRONMENT=Development
+    - AUTHORITY=http://valid_auth_server
+    - ISSUER=http://localhost:5002
+    - AUDIENCE=api1
+    - AUTHORITY_ANOTHER=http://another_valid_auth_server
+    - ISSUER_ANOTHER=http://localhost:5003
+    - VALIDATE_AUDIENCE__ANOTHER=false
+    - BACKEND_HOST_NAME=protected_api
+    - BACKEND_SERVICE_PORT=8080
+    - COLLECT_METRICS=false
+    - UNAUTHENTICATED_ROUTES=/isAlive,/foo*
+    - OPA_QUERY_PATH=protected_api/allow
+    - OPA_MODE=Enabled
+    - OPA_URL=http://opa:8181
+    ports:
+    - "5006:5001"
+
   valid_auth_server:
     build: ../SampleAuthServer
     ports:

--- a/SampleAuthServer/Config.cs
+++ b/SampleAuthServer/Config.cs
@@ -26,7 +26,7 @@ namespace SampleAuthServer
 
                 AllowedScopes = { "api1", "api2" },
 
-                AccessTokenLifetime = 3600
+                AccessTokenLifetime = 3
             }
         };
     }

--- a/SampleAuthServer/Config.cs
+++ b/SampleAuthServer/Config.cs
@@ -26,7 +26,7 @@ namespace SampleAuthServer
 
                 AllowedScopes = { "api1", "api2" },
 
-                AccessTokenLifetime = 3
+                AccessTokenLifetime = 3600
             }
         };
     }

--- a/src/Provider.cs
+++ b/src/Provider.cs
@@ -5,9 +5,10 @@ namespace Airbag
         public string Name { get; set; }
         public string Issuer { get; set; }
         public string Audience { get; set; }
+        public bool ValidateAudience { get; set; }
         public string Authority { get; set; }
 
         public bool IsEmpty() => string.IsNullOrEmpty(Issuer) && string.IsNullOrEmpty(Audience) && string.IsNullOrEmpty(Authority);
-        public bool IsInvalid() => string.IsNullOrEmpty(Issuer) || string.IsNullOrEmpty(Audience) || string.IsNullOrEmpty(Authority);
+        public bool IsInvalid() => string.IsNullOrEmpty(Issuer) || (ValidateAudience && string.IsNullOrEmpty(Audience)) || string.IsNullOrEmpty(Authority);
     }
 }

--- a/src/Provider.cs
+++ b/src/Provider.cs
@@ -2,6 +2,11 @@ namespace Airbag
 {
     public class Provider
     {
+        public Provider()
+        {
+            ValidateAudience = true;
+        }
+
         public string Name { get; set; }
         public string Issuer { get; set; }
         public string Audience { get; set; }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -34,12 +34,13 @@ namespace Airbag
 
             var providers = _configuration.AsEnumerable()
                 .Select(pair => pair.Key)
-                .Where(key => key.StartsWith("ISSUER_") || key.StartsWith("AUDIENCE_") || key.StartsWith("AUTHORITY_"))
-                .GroupBy(key => string.Join("_", key.Split('_').Skip(1)))
+                .Where(key => key.StartsWith("ISSUER_") || key.StartsWith("AUDIENCE_") || key.StartsWith("AUTHORITY_") || key.StartsWith("VALIDATE_AUDIENCE_"))
+                .GroupBy(key => string.Join("_", key.Split('_').Last()))
                 .Select(grouping => new Provider
                 {
                     Name = grouping.Key,
                     Issuer = _configuration.GetValue<string>("ISSUER_" + grouping.Key),
+                    ValidateAudience = bool.Parse(_configuration.GetValue<string>("VALIDATE_AUDIENCE_" + grouping.Key, "true")),
                     Audience = _configuration.GetValue<string>("AUDIENCE_" + grouping.Key),
                     Authority = _configuration.GetValue<string>("AUTHORITY_" + grouping.Key)
                 })
@@ -74,7 +75,7 @@ namespace Airbag
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidIssuer = provider.Issuer,
-                        ValidAudience = provider.Audience,
+                        ValidateAudience = false,
                         ValidateLifetime = true
                     };
 

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -75,7 +75,8 @@ namespace Airbag
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidIssuer = provider.Issuer,
-                        ValidateAudience = false,
+                        ValidateAudience = provider.ValidateAudience,
+                        ValidAudience = provider.Audience,
                         ValidateLifetime = true
                     };
 


### PR DESCRIPTION
AWS cognito does not set the `aud` claim - so in order to support it, airbag has to support providers without an audience. Added an option to disable audience validation (careful!)