### PR TITLE
chore(ci): changing to a newer github integration in codefresh

### DIFF
--- a/deployment/SampleAuthServer-Dockerfile
+++ b/deployment/SampleAuthServer-Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore-build:2.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:2.1 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY SampleAuthServer/. ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0
+FROM mcr.microsoft.com/dotnet/aspnet:2.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "SampleAuthServer.dll"]

--- a/deployment/codefresh/publish.yaml
+++ b/deployment/codefresh/publish.yaml
@@ -25,7 +25,7 @@ spec:
       provider: github
       disabled: false
       verified: true
-      context: github-verified
+      context: github-solutobuild-soluto-public
       contexts: []
       variables: []
 
@@ -40,7 +40,7 @@ spec:
       repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
       revision: ${{CF_REVISION}}
       stage: build
-      git: github
+      git: github-solutobuild-soluto-public
 
     BuildImage:
       stage: build

--- a/deployment/codefresh/test.yaml
+++ b/deployment/codefresh/test.yaml
@@ -28,7 +28,7 @@ spec:
       provider: github
       disabled: false
       verified: true
-      context: github-verified
+      context: github-solutobuild-soluto-public
       contexts: []
       variables: []
 
@@ -43,7 +43,7 @@ spec:
       repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
       revision: ${{CF_REVISION}}
       stage: build
-      git: github
+      git: github-solutobuild-soluto-public
 
     UnitTests:
       stage: build


### PR DESCRIPTION
Fixing the clone in the CI system with a new Github integration

Docker migration:
1. https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-6.0#update-to-the-21-docker-images
2. https://stackoverflow.com/questions/49798012/aspnetcore2-1-not-found
3. https://hub.docker.com/_/microsoft-dotnet

Soluto/airbag#103