### PR TITLE
setting the `CF_RELEASE_TAG` as the variable to tag with when pushing a new tag to github

### DIFF
--- a/deployment/codefresh/publish.yaml
+++ b/deployment/codefresh/publish.yaml
@@ -20,7 +20,7 @@ spec:
         - push.tags
       pullRequestAllowForkEvents: false
       commentRegex: /.*/gi
-      branchRegex: /.*/gi
+      branchRegex: /master/gi
       branchRegexInput: regex
       provider: github
       disabled: false

--- a/deployment/codefresh/publish.yaml
+++ b/deployment/codefresh/publish.yaml
@@ -69,7 +69,7 @@ spec:
       candidate: ${{BuildImage}}
       tags:
         - latest
-        - '${{CF_BRANCH}}'
+        - '${{CF_RELEASE_TAG}}'
       when:
         condition:
           all:


### PR DESCRIPTION
Eventually, I removed the `build&publish` pipeline manually and decided to leave only the `test` & `publish`.
The `test` pipeline triggers on `pull request open`, and the `publish` pipeline triggers only on new tags that are being pushed to `master` branch

closes #106 